### PR TITLE
Improve GPU compatibility and performance

### DIFF
--- a/zoom.py
+++ b/zoom.py
@@ -7,19 +7,39 @@ from PIL import Image
 import PIL.Image
 from io import BytesIO
 from IPython.display import Image, display
-from matplotlib import cm # make sure matplotlib 3.0+ is installed
+from matplotlib import cm  # make sure matplotlib 3.0+ is installed
 import matplotlib
 
 print("TensorFlow version:", tf.__version__)
+
+# Configure TensorFlow to use the GPU when available. This also allows the code
+# to run on systems without a GPU, such as the execution environment used for
+# testing. On a V100 or any other CUDA-capable card, TensorFlow will place the
+# computation on the first visible GPU.
+gpus = tf.config.list_physical_devices('GPU')
+if gpus:
+    try:
+        for gpu in gpus:
+            tf.config.experimental.set_memory_growth(gpu, True)
+        DEVICE = '/GPU:0'
+        print("GPU found, using", gpus[0].name)
+    except RuntimeError as e:
+        print(e)
+        DEVICE = '/CPU:0'
+else:
+    DEVICE = '/CPU:0'
+    print("No GPU found, using CPU")
+
 from argparse import ArgumentParser
+
 
 def build_parser():
     parser = ArgumentParser()
-    
+
     parser.add_argument('--max-iterations', type=int,
                         dest='max_iterations', help='maximum number of times to iterate logisitc mapping',
                         metavar='MAX_ITERATIONS', default=2000)
-    
+
     parser.add_argument('--x-res', type=int,
                         dest='x_res', help='resolution of samples along the x-axis',
                         metavar='X_RES', default=512)
@@ -31,11 +51,11 @@ def build_parser():
     parser.add_argument('--x-center', type=float,
                         dest='x_center', help='x coordinate in the complex plane to start the zoom at',
                         metavar='X_CENTER', default=-0.75)
-    
+
     parser.add_argument('--x-width', type=float,
                         dest='x_width', help='starting width of the sample window in the complex plane',
                         metavar='X_WIDTH', default=2.5)
-    
+
     parser.add_argument('--y-center', type=float,
                         dest='y_center', help='y coordinate in the complex plane to start the zoom at',
                         metavar='Y_CENTER', default=0)
@@ -66,15 +86,14 @@ def build_parser():
                         dest='frames_path', help='path to the directory in which to store the individual frames',
                         metavar='FRAMES_PATH', default='./frames')
 
-    
     parser.add_argument('--show-edges', help='render the edge detection beside',
                         dest='show_edges', action="store_true")
 
     return parser
-  
+
+
 HORIZON = 4
 #LOG_HORIZON = np.log(np.log(HORIZON))/np.log(2)
-    
 
 
 class mandelbrot_generator:
@@ -86,107 +105,106 @@ class mandelbrot_generator:
                 y_center=0,
                 y_width=2.5,
                 max_n=2000):
-        
-        self.x_res = np.float128(x_res)
-        self.y_res = np.float128(y_res)
-        self.x_center = np.float128(x_center)
-        self.x_width = np.float128(x_width)
-        self.y_center = np.float128(y_center)
-        self.y_width = np.float128(y_width)
-        self.max_n = max_n
-        
-        _, Z, edges = self.process()
-        
+
+        # Use float64 so that the values can be transferred to the GPU. The
+        # previous implementation relied on float128 which is not supported by
+        # most accelerators.
+        self.x_res = np.float64(x_res)
+        self.y_res = np.float64(y_res)
+        self.x_center = np.float64(x_center)
+        self.x_width = np.float64(x_width)
+        self.y_center = np.float64(y_center)
+        self.y_width = np.float64(y_width)
+        self.max_n = int(max_n)
+
         # choose an edge point at random to focus on
+        _, Z, edges = self.process()
         edge_indices = np.argwhere(edges == 1)
         zoom_center = edge_indices[np.random.choice(len(edge_indices))]
-        
+
         # recenter to the focus point
         self.x_center = Z[zoom_center[0], zoom_center[1]].real
         self.y_center = Z[zoom_center[0], zoom_center[1]].imag
 
-    def step(self, _xs, _zs, _ns, prev_not_diverged):
-        _zs = _zs*_zs + _xs
-
-        az =  tf.abs(_zs)
+    @tf.function
+    def _step(self, zs, xs, ns):
+        """Perform a single Mandelbrot iteration."""
+        zs = zs * zs + xs
+        az = tf.abs(zs)
         not_diverged = az < HORIZON
-        _ns = tf.add(_ns, tf.cast(not_diverged, tf.int32))
-        # add the antialiasing bias to newly diverged samples
-        #newly_diverged = np.logical_xor(not_diverged, prev_not_diverged)
-        #antialiasing_bias = -np.log(np.log(az))/np.log(2) + LOG_HORIZON
-        #_ns = tf.add(_ns, np.multiply(newly_diverged, antialiasing_bias))
-        return _xs, _zs, _ns, np.array(not_diverged)
+        ns = ns + tf.cast(not_diverged, tf.int32)
+        return zs, ns, not_diverged
+
+    @tf.function
+    def _run(self, xs, zs, ns):
+        """Iterate the Mandelbrot formula using a TensorFlow while loop."""
+        i = tf.constant(0, dtype=tf.int32)
+        not_diverged = tf.ones_like(ns, tf.bool)
+
+        def cond(i, zs, ns, not_diverged):
+            return tf.less(i, self.max_n)
+
+        def body(i, zs, ns, not_diverged):
+            zs, ns, not_diverged = self._step(zs, xs, ns)
+            return i + 1, zs, ns, not_diverged
+
+        return tf.while_loop(cond, body, [i, zs, ns, not_diverged])
 
     def process(self):
-        x_min = self.x_center - self.x_width/2
-        x_max = self.x_center + self.x_width/2
-        y_min = self.y_center - self.y_width/2
-        y_max = self.y_center + self.y_width/2
-        h_x = (x_max - x_min) / self.x_res
-        h_y = (y_max - y_min) / self.y_res
+        x_min = self.x_center - self.x_width / 2
+        x_max = self.x_center + self.x_width / 2
+        y_min = self.y_center - self.y_width / 2
+        y_max = self.y_center + self.y_width / 2
 
-        X, Y = np.meshgrid(np.r_[x_min:x_max:h_x], np.r_[y_min:y_max:h_y])
-        Z = X + 1j*Y
+        with tf.device(DEVICE):
+            x = tf.linspace(x_min, x_max, int(self.x_res))
+            y = tf.linspace(y_min, y_max, int(self.y_res))
+            X, Y = tf.meshgrid(x, y)
+            Z = tf.complex(X, Y)
+            xs = tf.identity(Z)
+            zs = tf.identity(xs)
+            ns = tf.zeros_like(xs, tf.int32)
 
-        xs = tf.constant(Z.astype(np.complex128))
-        zs = tf.Variable(xs)
-        ns = tf.Variable(tf.zeros_like(xs, tf.int32))
-        not_diverged = np.bool(np.ones_like(ns))
-        
-        iterations = 0
-#         temp = 2.0
-#         thresh = 1e-2
+            iterations, zs, ns, not_diverged = self._run(xs, zs, ns)
+            iter_matrix = tf.fill(tf.shape(ns), iterations)
+            mask = tf.cast(tf.clip_by_value(iter_matrix - ns, 0, 1), tf.bool)
+            edges = tf.math.logical_xor(tf.roll(mask, 1, axis=0), mask)
 
-        for i in range(self.max_n): 
-            xs, zs, ns, not_diverged = self.step(xs, zs, ns, not_diverged)
+        return (iter_matrix - ns).numpy(), Z.numpy(), edges.numpy()
 
-#             # double the iterations each time the threshold is not met
-#             if ((i & (i-1) == 0) and i != 0):
-#                 print(i)
-#                 convergence_ratio = np.sum(not_diverged) / not_diverged.size
-#                 if (temp - convergence_ratio < thresh):
-#                     iterations = i + 1
-#                     break
-#                 temp = convergence_ratio
-
-            iterations = i + 1
-        
-        # edge detection
-        edges = np.logical_xor(np.roll(np.clip(iterations - np.array(ns), 0 ,1), 1, axis=0), np.clip(iterations - np.array(ns), 0 ,1))
-        
-        return iterations - np.array(ns), Z, edges
-          
     def next_image(self, zoom_factor=0.9):
         fractal, Z, edges = self.process()
-    
+
         # choose an edge point nearest to the center
         zoom_center = [0, 0]
         for i in range(min(edges.shape[0], edges.shape[1]) // 2):
             mask = np.zeros_like(edges)
-            mask[mask.shape[0]//2-i:mask.shape[0]//2+i, mask.shape[1]//2-i:mask.shape[1]//2+i] = 1
+            mask[mask.shape[0]//2-i:mask.shape[0]//2+i,
+                 mask.shape[1]//2-i:mask.shape[1]//2+i] = 1
             edge_indices = np.argwhere(np.multiply(edges, mask) == 1)
             if edge_indices.size != 0:
                 zoom_center = edge_indices[np.random.choice(len(edge_indices))]
                 break
 
-        #recenter
+        # recenter
         self.x_center = Z[zoom_center[0], zoom_center[1]].real
         self.y_center = Z[zoom_center[0], zoom_center[1]].imag
 
-        #zoom
-        self.x_width *= np.float128(zoom_factor)
-        self.y_width *= np.float128(zoom_factor)
+        # zoom
+        self.x_width *= np.float64(zoom_factor)
+        self.y_width *= np.float64(zoom_factor)
         return fractal, edges
+
 
 def main():
     parser = build_parser()
     opt = parser.parse_args()
-    
-    image_generator = mandelbrot_generator(opt.x_res, 
-                                           opt.y_res, 
-                                           opt.x_center, 
-                                           opt.x_width, 
-                                           opt.y_center, 
+
+    image_generator = mandelbrot_generator(opt.x_res,
+                                           opt.y_res,
+                                           opt.x_center,
+                                           opt.x_width,
+                                           opt.y_center,
                                            opt.y_width,
                                            opt.max_iterations)
     images = []
@@ -196,7 +214,7 @@ def main():
         import os
         try:
             os.mkdir(opt.frames_path)
-        except:
+        except Exception:
             pass
 
     for i in range(opt.frames):
@@ -204,22 +222,22 @@ def main():
         fractal, edges = image_generator.next_image(zoom_factor=opt.zoom_factor)
 
         if opt.save_mono:
-            img = PIL.Image.fromarray( np.uint8( 255 * (np.abs((fractal%512)-255) / 256) ) )
+            img = PIL.Image.fromarray(
+                np.uint8(255 * (np.abs((fractal % 512) - 255) / 256)))
             img.save(os.path.join(opt.frames_path, 'mono{0:03d}.{1}'.format(i, opt.format)))
 
-        fractal = np.uint8(cm.twilight_shifted(fractal%512)*255)
+        fractal = np.uint8(cm.twilight_shifted(fractal % 512) * 255)
         if opt.show_edges:
             edges = np.uint8(np.stack((edges,)*4, axis=-1)*255)
             img = PIL.Image.fromarray(np.concatenate((fractal, edges), axis=1))
             images.append(img)
-            if opt.save_frames:	
+            if opt.save_frames:
                 img.save(os.path.join(opt.frames_path, 'frame{0:03d}.{1}'.format(i, opt.format)))
         else:
             img = PIL.Image.fromarray(fractal)
             images.append(img)
-            if opt.save_frames:	
+            if opt.save_frames:
                 img.save(os.path.join(opt.frames_path, 'frame{0:03d}.{1}'.format(i, opt.format)))
-
 
     import imageio
     images[0].save('movie.gif',
@@ -227,7 +245,8 @@ def main():
                    append_images=images[1:],
                    duration=100,
                    loop=0)
-    
+
+
 if __name__ == '__main__':
     main()
 


### PR DESCRIPTION
## Summary
- run TensorFlow with GPU memory growth and CPU fallback
- replace float128 with float64 to support GPU tensors
- use TensorFlow `while_loop` to iterate Mandelbrot set on device for faster execution

## Testing
- `python zoom.py --frames 1 --max-iterations 5 --x-res 32 --y-res 32`


------
https://chatgpt.com/codex/tasks/task_e_68c3167b46d4832fadc1cdcea56d4eac