### PR TITLE
Add ROCm-specific Python requirements

### DIFF
--- a/requirements-rocm.txt
+++ b/requirements-rocm.txt
@@ -1,0 +1,7 @@
+ipython>=9.0
+matplotlib>=3.10
+numpy>=1.26
+Pillow>=11.0
+tensorflow-rocm>=2.17
+wrapt>=1.17
+imageio>=2.37


### PR DESCRIPTION
## Summary
- add a requirements-rocm.txt file that replaces the CUDA TensorFlow dependency with tensorflow-rocm for AMD GPU environments

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9b91ada44832f917c3076ead38a9c