### PR TITLE
Refactor Mandelbrot zoom pipeline into reusable modules

### DIFF
--- a/mandelbrot/__init__.py
+++ b/mandelbrot/__init__.py
@@ -1,0 +1,24 @@
+"""Public API for Mandelbrot rendering utilities."""
+
+from .renderer import RenderParameters, RenderResult, SamplingMetadata, render_frame
+from .generator import (
+    ZoomPlanner,
+    apply_zoom,
+    compute_zoom_factors,
+    pixel_to_complex,
+    recenter_params,
+    select_zoom_center,
+)
+
+__all__ = [
+    "RenderParameters",
+    "RenderResult",
+    "SamplingMetadata",
+    "ZoomPlanner",
+    "apply_zoom",
+    "compute_zoom_factors",
+    "pixel_to_complex",
+    "recenter_params",
+    "render_frame",
+    "select_zoom_center",
+]

--- a/mandelbrot/generator.py
+++ b/mandelbrot/generator.py
@@ -1,0 +1,127 @@
+"""Utilities for managing Mandelbrot zoom sequences."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+import numpy as np
+
+from .renderer import RenderParameters, RenderResult, SamplingMetadata
+
+
+@dataclass(frozen=True)
+class ZoomPlanner:
+    """Maintain the parameter updates for a Mandelbrot zoom sequence."""
+
+    lock_aspect: bool
+    aspect: float
+
+    def enforce_aspect(self, params: RenderParameters) -> RenderParameters:
+        if not self.lock_aspect:
+            return params
+        new_y_width = np.float64(params.x_width) * np.float64(self.aspect)
+        return replace(params, y_width=float(new_y_width))
+
+    def initialize_focus(self, params: RenderParameters, result: RenderResult) -> RenderParameters:
+        focus_pixel = select_zoom_center(result.edges)
+        return recenter_params(params, focus_pixel, result.metadata)
+
+    def update_after_frame(self, params: RenderParameters, result: RenderResult, zoom_factor: float) -> RenderParameters:
+        focus_pixel = select_zoom_center(result.edges)
+        params = recenter_params(params, focus_pixel, result.metadata)
+        return apply_zoom(params, zoom_factor, self.lock_aspect, self.aspect)
+
+
+def compute_zoom_factors(frames: int, zoom_factor: float, *, final_zoom: float | None, easing: str) -> np.ndarray:
+    """Compute per-frame zoom multipliers for the animation."""
+
+    if frames <= 0:
+        return np.array([], dtype=np.float64)
+
+    if final_zoom is not None and final_zoom > 0:
+        total_frames = max(1, frames)
+        log_target = np.log(final_zoom)
+        easing_mode = easing.lower()
+
+        def ease_in_out(t: float) -> float:
+            return 3 * t ** 2 - 2 * t ** 3
+
+        ease = (lambda u: u) if easing_mode == "linear" else ease_in_out
+        if total_frames == 1:
+            alphas = np.array([1.0], dtype=np.float64)
+        else:
+            alphas = np.array([ease(i / (total_frames - 1)) for i in range(total_frames)], dtype=np.float64)
+        alphas = np.clip(alphas, 0.0, 1.0)
+        increments = np.diff(np.concatenate(([0.0], alphas)))
+        per_frame_logs = increments * log_target
+        if frames < total_frames:
+            per_frame_logs = per_frame_logs[:frames]
+        return np.exp(per_frame_logs)
+
+    return np.full(frames, np.float64(zoom_factor), dtype=np.float64)
+
+
+def select_zoom_center(edges: np.ndarray) -> np.ndarray:
+    """Select a deterministic focus pixel near the center of the edge map."""
+
+    if edges.size == 0:
+        return np.array([edges.shape[0] // 2, edges.shape[1] // 2], dtype=np.int64)
+
+    height, width = edges.shape
+    center_row = height // 2
+    center_col = width // 2
+    max_radius = max(height, width)
+
+    for radius in range(max_radius):
+        row_start = max(center_row - radius, 0)
+        row_end = min(center_row + radius + 1, height)
+        col_start = max(center_col - radius, 0)
+        col_end = min(center_col + radius + 1, width)
+        region = edges[row_start:row_end, col_start:col_end]
+        if np.any(region):
+            indices = np.argwhere(region)
+            indices[:, 0] += row_start
+            indices[:, 1] += col_start
+            return _select_zoom_center(indices, edges.shape)
+
+    edge_indices = np.argwhere(edges)
+    if edge_indices.size:
+        return _select_zoom_center(edge_indices, edges.shape)
+    return np.array([center_row, center_col], dtype=np.int64)
+
+
+def _select_zoom_center(edge_indices: np.ndarray, shape: tuple[int, int]) -> np.ndarray:
+    if edge_indices.size == 0:
+        return np.array([shape[0] // 2, shape[1] // 2], dtype=np.int64)
+
+    center = np.array([(shape[0] - 1) / 2.0, (shape[1] - 1) / 2.0], dtype=np.float64)
+    indices = edge_indices.astype(np.float64, copy=False)
+    distances = np.sum((indices - center) ** 2, axis=1)
+    best_idx = int(np.argmin(distances))
+    return edge_indices[best_idx]
+
+
+def recenter_params(params: RenderParameters, pixel: np.ndarray, metadata: SamplingMetadata) -> RenderParameters:
+    x_center, y_center = pixel_to_complex(metadata, pixel[0], pixel[1])
+    return replace(params, x_center=float(x_center), y_center=float(y_center))
+
+
+def apply_zoom(params: RenderParameters, zoom_factor: float, lock_aspect: bool, aspect: float) -> RenderParameters:
+    x_width = np.float64(params.x_width) * np.float64(zoom_factor)
+    if lock_aspect:
+        y_width = np.float64(x_width) * np.float64(aspect)
+    else:
+        y_width = np.float64(params.y_width) * np.float64(zoom_factor)
+    return replace(params, x_width=float(x_width), y_width=float(y_width))
+
+
+def pixel_to_complex(metadata: SamplingMetadata, row: int, col: int) -> tuple[np.float64, np.float64]:
+    if metadata.x_res > 1:
+        x = np.float64(metadata.x_min) + np.float64(col) * np.float64(metadata.x_step)
+    else:
+        x = np.float64(metadata.x_min)
+    if metadata.y_res > 1:
+        y = np.float64(metadata.y_min) + np.float64(row) * np.float64(metadata.y_step)
+    else:
+        y = np.float64(metadata.y_min)
+    return np.float64(x), np.float64(y)

--- a/mandelbrot/renderer.py
+++ b/mandelbrot/renderer.py
@@ -1,0 +1,153 @@
+"""Rendering primitives for Mandelbrot frames."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+import tensorflow as tf
+
+HORIZON = 4
+
+
+@dataclass(frozen=True)
+class RenderParameters:
+    """Parameters that describe a single render of the Mandelbrot set."""
+
+    x_res: int
+    y_res: int
+    x_center: float
+    y_center: float
+    x_width: float
+    y_width: float
+    max_iterations: int
+
+
+@dataclass(frozen=True)
+class SamplingMetadata:
+    """Metadata describing the sampling grid for a rendered frame."""
+
+    x_min: float
+    y_min: float
+    x_step: float
+    y_step: float
+    x_res: int
+    y_res: int
+
+
+@dataclass(frozen=True)
+class RenderResult:
+    """Container for the numerical results of a Mandelbrot render."""
+
+    smooth: np.ndarray
+    iterations: np.ndarray
+    edges: np.ndarray
+    metadata: SamplingMetadata
+
+
+@tf.function
+def _mandelbrot_step(zs: tf.Tensor, xs: tf.Tensor, ns: tf.Tensor, active: tf.Tensor) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor]:
+    """Perform a single Mandelbrot iteration for points that have not diverged."""
+
+    zs_new = zs * zs + xs
+    zs = tf.where(active, zs_new, zs)
+    ns = ns + tf.cast(active, tf.int32)
+    az = tf.abs(zs)
+    horizon = tf.cast(HORIZON, az.dtype)
+    new_active = tf.logical_and(active, az < horizon)
+    return zs, ns, new_active
+
+
+@tf.function
+def _mandelbrot_run(xs: tf.Tensor, zs: tf.Tensor, ns: tf.Tensor, max_iterations: tf.Tensor) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor, tf.Tensor]:
+    """Iterate the Mandelbrot formula using a TensorFlow while loop."""
+
+    max_iterations = tf.cast(max_iterations, tf.int32)
+    i = tf.constant(0, dtype=tf.int32)
+    active = tf.ones_like(ns, tf.bool)
+
+    def cond(i: tf.Tensor, zs: tf.Tensor, ns: tf.Tensor, active: tf.Tensor) -> tf.Tensor:
+        return tf.logical_and(tf.less(i, max_iterations), tf.reduce_any(active))
+
+    def body(i: tf.Tensor, zs: tf.Tensor, ns: tf.Tensor, active: tf.Tensor) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor, tf.Tensor]:
+        zs, ns, active = _mandelbrot_step(zs, xs, ns, active)
+        return i + 1, zs, ns, active
+
+    return tf.while_loop(cond, body, (i, zs, ns, active))
+
+
+def _compute_metadata(params: RenderParameters) -> SamplingMetadata:
+    x_res = max(int(params.x_res), 1)
+    y_res = max(int(params.y_res), 1)
+
+    x_width = np.float64(params.x_width)
+    y_width = np.float64(params.y_width)
+    x_center = np.float64(params.x_center)
+    y_center = np.float64(params.y_center)
+
+    x_min = x_center - x_width / 2.0
+    x_max = x_center + x_width / 2.0
+    y_min = y_center - y_width / 2.0
+    y_max = y_center + y_width / 2.0
+
+    x_step = np.float64((x_max - x_min) / (x_res - 1)) if x_res > 1 else np.float64(0.0)
+    y_step = np.float64((y_max - y_min) / (y_res - 1)) if y_res > 1 else np.float64(0.0)
+
+    return SamplingMetadata(
+        x_min=float(x_min),
+        y_min=float(y_min),
+        x_step=float(x_step),
+        y_step=float(y_step),
+        x_res=x_res,
+        y_res=y_res,
+    )
+
+
+def render_frame(params: RenderParameters, *, device: Optional[str] = None) -> RenderResult:
+    """Render a Mandelbrot frame given the supplied parameters."""
+
+    metadata = _compute_metadata(params)
+    x_res = metadata.x_res
+    y_res = metadata.y_res
+
+    x = np.linspace(metadata.x_min, metadata.x_min + metadata.x_step * (x_res - 1), x_res, dtype=np.float64) if x_res > 1 else np.array([metadata.x_min], dtype=np.float64)
+    y = np.linspace(metadata.y_min, metadata.y_min + metadata.y_step * (y_res - 1), y_res, dtype=np.float64) if y_res > 1 else np.array([metadata.y_min], dtype=np.float64)
+
+    max_iterations = tf.constant(params.max_iterations, dtype=tf.int32)
+
+    with tf.device(device if device is not None else "/CPU:0"):
+        x_tf = tf.convert_to_tensor(x, dtype=tf.float64)
+        y_tf = tf.convert_to_tensor(y, dtype=tf.float64)
+        X, Y = tf.meshgrid(x_tf, y_tf)
+        Z = tf.complex(X, Y)
+        xs = tf.identity(Z)
+        zs = tf.identity(xs)
+        ns = tf.zeros_like(xs, tf.int32)
+
+        _, zs, ns, _ = _mandelbrot_run(xs, zs, ns, max_iterations)
+
+        az = tf.abs(zs)
+        eps = tf.constant(1e-12, dtype=az.dtype)
+        az_safe = tf.maximum(az, tf.constant(1.0, dtype=az.dtype) + eps)
+        log_az = tf.math.log(az_safe)
+        log_log_az = tf.math.log(tf.maximum(log_az, eps))
+        ns_float = tf.cast(ns, tf.float64)
+        log2 = tf.math.log(tf.constant(2.0, dtype=az.dtype))
+        smooth_escape = ns_float + tf.constant(1.0, dtype=ns_float.dtype) - log_log_az / log2
+        escaped = tf.less(ns, max_iterations)
+        smooth = tf.where(escaped, smooth_escape, tf.cast(max_iterations, tf.float64))
+
+        max_tensor = tf.cast(max_iterations, ns.dtype)
+        mask = tf.cast(
+            tf.clip_by_value(tf.fill(tf.shape(ns), max_tensor) - ns, 0, 1),
+            tf.bool,
+        )
+        edges = tf.math.logical_xor(tf.roll(mask, 1, axis=0), mask)
+
+    return RenderResult(
+        smooth=smooth.numpy(),
+        iterations=ns.numpy(),
+        edges=edges.numpy(),
+        metadata=metadata,
+    )


### PR DESCRIPTION
## Summary
- extract Mandelbrot rendering primitives into a new mandelbrot.renderer module with reusable dataclasses and a pure render_frame function
- add a ZoomPlanner helper and supporting utilities for deterministic zoom focus and zoom-factor generation
- update zoom.py to orchestrate rendering through the new modules without the monolithic mandelbrot_generator class

## Testing
- python -m compileall zoom.py mandelbrot


------
https://chatgpt.com/codex/tasks/task_e_68cb1b2cd6cc832f89c1aa6bdfef52eb