### PR TITLE
Add coordinate overlay option for final image

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ the proposed CLI redesign to support explicit output modes.
 - `--format`           File format for saved frames (e.g. `png`, `jpeg`). Default: `png`
 - `--frames-path`      Directory to store individual frames. Default: `./frames`
 - `--show-edges`       Render edge detection alongside the Mandelbrot zoom
+- `--show-coordinates` Overlay the final frame with axis bounds and highlight the complex origin
 
 ## How does it know where to zoom?
 


### PR DESCRIPTION
## Summary
- add a --show-coordinates CLI option to annotate the final frame with axis bounds and the complex origin
- render an information box and origin marker through a new annotate_with_coordinates helper
- document the new overlay option in the README

## Testing
- python -m compileall zoom.py mandelbrot

------
https://chatgpt.com/codex/tasks/task_e_68cb206753f0832f9e5f84d682744f3e