### PR TITLE
Fix edge mask wrap-around in renderer

### DIFF
--- a/mandelbrot/renderer.py
+++ b/mandelbrot/renderer.py
@@ -143,7 +143,8 @@ def render_frame(params: RenderParameters, *, device: Optional[str] = None) -> R
             tf.clip_by_value(tf.fill(tf.shape(ns), max_tensor) - ns, 0, 1),
             tf.bool,
         )
-        edges = tf.math.logical_xor(tf.roll(mask, 1, axis=0), mask)
+        shifted_mask = tf.pad(mask[:-1], [[1, 0], [0, 0]], constant_values=False)
+        edges = tf.math.logical_xor(shifted_mask, mask)
 
     return RenderResult(
         smooth=smooth.numpy(),


### PR DESCRIPTION
## Summary
- stop wrapping the edge detector when shifting the mask so the first row is not treated as adjacent to the last

## Testing
- python -m compileall mandelbrot

------
https://chatgpt.com/codex/tasks/task_e_68d14a7afb9c832f90679f4480ff9e88