### PR TITLE
Improve README with expanded recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Generate deep, smooth Mandelbrot-set zooms from the command line using TensorFlow. The project focuses on producing high quality animations while remaining approachable for quick experiments and short-form clips.
 
-The CLI aims to be self-documenting, yet a few options merit extra context—especially the ones that control how the window is framed and how colour is mapped. This document walks through the most common workflows and calls out less obvious switches such as `--lock-aspect` or the tone-mapping controls so you can make informed choices.
+Although the CLI exposes descriptive flag names, the number of combinations can feel daunting when you are new to fractal rendering. This guide distils the practical knowledge you need to run your first zoom, explains how the framing maths works, and provides several production-ready presets so you can adapt them without guesswork.
 
 <p align="center">
   <img src="examples/movie.gif" height="512px" alt="Animated Mandelbrot zoom" />
@@ -56,12 +56,13 @@ pip install -r requirements-rocm.txt
    ```bash
    python zoom.py
    ```
+   The script renders 100 frames at 512×512 pixels using a smooth ease-in/ease-out curve and the `twilight_shifted` colour palette.
 3. Tweak the resolution or duration by adding flags:
    ```bash
    python zoom.py --frames 120 --x-res 768 --y-res 768
    ```
 
-The default animation uses a smooth twilight color palette, stays centered on interesting edges, and writes the animation to `movie.gif` in the working directory.
+Every run auto-centres on intricate edges that enter the frame and writes the final animation to `movie.gif` in the working directory unless you override the output path.
 
 ### Keeping the image square
 
@@ -75,17 +76,55 @@ This keeps `y_width = x_width × (y_res / x_res)` for every frame so that circle
 
 ## Recipes and examples
 
-The following commands demonstrate common workflows. Combine options to tailor the zoom to your taste.
+The following presets cover common workflows and highlight how different options interact. Mix and match them, or use them as starting points for your own renders.
 
-| Goal | Command | Notes |
-|------|---------|-------|
-| **Fast preview (CPU)** | `python zoom.py --frames 48 --x-res 320 --y-res 320 --zoom-factor 0.9` | Generates a ~2 second GIF that renders quickly on most laptops. |
-| **Deep dive (CPU)** | `python zoom.py --frames 480 --zoom-factor 0.97 --max-iterations 4000 --lock-aspect` | Slow but detailed 20 second animation. `--lock-aspect` keeps the frame square as you experiment with widths. |
-| **GPU accelerated render** | `CUDA_VISIBLE_DEVICES=0 python zoom.py --frames 360 --x-res 1024 --y-res 1024` | Renders in high resolution if a CUDA-capable GPU is available. |
-| **Highlight the fractal edges** | `python zoom.py --show-edges` | Saves a side-by-side animation of the color image and its detected edges (`examples/edges.gif` shows the effect). |
-| **Label the coordinates** | `python zoom.py --frames 240 --show-coordinates --zoom-factor 0.94` | Overlays the complex plane window of the final frame. |
-| **Try a different palette** | `python zoom.py --colormap plasma` | Any Matplotlib colormap is supported (`viridis`, `magma`, `cividis`, …). |
-| **Monochrome sequence for compositing** | `python zoom.py --mode mono --frame-dir ./mono_frames --format png` | Produces grayscale frames ready for further processing. |
+1. **Rapid CPU preview** – confirm the framing and colour palette before a long render.
+   ```bash
+   python zoom.py --frames 48 --x-res 320 --y-res 320 --zoom-factor 0.9
+   ```
+   Produces a ~2 second GIF that renders in well under a minute on a laptop while keeping enough detail to judge the composition.
+
+2. **Balanced default-plus** – extend the stock animation for social posts without overwhelming render times.
+   ```bash
+   python zoom.py --frames 180 --x-res 640 --y-res 640 --zoom-factor 0.92 --max-iterations 2600
+   ```
+   Slightly increases the resolution and frame count, revealing finer filaments while remaining CPU friendly.
+
+3. **Ultra-deep dive** – explore fine structure for desktop wallpapers or archival frames.
+   ```bash
+   python zoom.py --frames 480 --zoom-factor 0.97 --max-iterations 4000 --lock-aspect
+   ```
+   Keeps the aspect ratio square while the high iteration cap resolves thin tendrils. Expect a long render unless a GPU is available.
+
+4. **High-resolution GPU render** – lean on CUDA acceleration for crisp output.
+   ```bash
+   CUDA_VISIBLE_DEVICES=0 python zoom.py --frames 360 --x-res 1024 --y-res 1024 --zoom-factor 0.94
+   ```
+   Ensures TensorFlow selects the first GPU and ups the resolution to 1K² for publication-ready animations.
+
+5. **Edge detective** – visualise how the auto-centering keeps interesting geometry in view.
+   ```bash
+   python zoom.py --frames 180 --zoom-factor 0.92 --show-edges --colormap viridis
+   ```
+   Generates a split-screen GIF with Sobel edge detection on the right (`examples/edges.gif` shows the layout).
+
+6. **Annotated lecture clip** – add overlays for workshops or tutorials.
+   ```bash
+   python zoom.py --frames 240 --show-coordinates --zoom-factor 0.94 --x-res 768 --y-res 432 --lock-aspect
+   ```
+   Presents the bounds of the complex plane on the final frame while `--lock-aspect` keeps circles round even at a 16:9 resolution.
+
+7. **Palette swapper** – quickly preview Matplotlib colour maps.
+   ```bash
+   python zoom.py --frames 120 --zoom-factor 0.9 --colormap plasma
+   ```
+   Any palette supported by Matplotlib (`viridis`, `inferno`, `cividis`, …) can be slotted in to shape the mood of the render.
+
+8. **Monochrome compositing pass** – prepare greyscale layers for external pipelines.
+   ```bash
+   python zoom.py --mode mono --mode frames --frame-dir ./mono_frames --format png --frames 200
+   ```
+   Writes individual monochrome PNGs to `./mono_frames` and keeps the GIF, making it easy to grade or composite in other tools.
 
 ### Controlling the zoom curve
 
@@ -94,13 +133,15 @@ Two parameters define how aggressively the window shrinks:
 - `--zoom-factor` multiplies the window size every frame (values `< 1` zoom in, values `> 1` zoom out).
 - `--final-zoom` lets you state the total scale of the last frame—useful when you know you want to end at, say, `1e-6` of the original width. When provided, the script computes a matching per-frame factor and ignores `--zoom-factor`.
 
-For non-linear motion, pick an easing curve:
+For non-linear motion, pick an easing curve. The default `ease` acceleration pattern starts gently, speeds up mid-way, and glides to the final scale. Switch to `linear` for constant speed, or `ease-in`/`ease-out` when you want dramatic anticipation or a lingering finish:
 
 ```bash
 python zoom.py --frames 240 --final-zoom 1e-5 --easing ease
+python zoom.py --frames 180 --final-zoom 1e-4 --easing linear
+python zoom.py --frames 150 --zoom-factor 0.86 --easing ease-out
 ```
 
-`--easing ease` (the default) accelerates slowly, speeds up mid-way, and gently comes to rest. Use `--easing linear` to keep a constant rate.
+When `--final-zoom` is present, the script derives a matching per-frame factor and ignores `--zoom-factor`, guaranteeing the final frame lands on the requested scale.
 
 ### Diving into specific locations
 
@@ -156,6 +197,14 @@ The resulting `preview.mp4` is a lightweight 3 second clip suitable for social n
 - `--invert` flips the colormap, while `--inside-color` (hex) controls the colour used for points inside the Mandelbrot set.
 
 Combine these with Matplotlib colormaps to build a consistent style guide for your animations.
+
+For a punchier render, lift the gamma slightly while trimming bright spikes and switching palettes:
+
+```bash
+python zoom.py --frames 150 --zoom-factor 0.9 --gamma 0.95 --clip-low 1 --clip-high 99 --colormap inferno
+```
+
+The histogram settings prevent isolated highlights from washing out the colour story, and the palette swap keeps the sequence cohesive.
 
 ## Working with saved frames
 


### PR DESCRIPTION
## Summary
- clarify the introduction and quick-start guidance so new users know what the default render produces
- expand the recipes section with eight detailed presets that cover CPU previews, GPU renders, overlays, and monochrome workflows
- document additional easing curve behaviour and provide a concrete tone-mapping example for colour grading tweaks

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d54aa04cac832fb90d64ddedce857d