### PR TITLE
Update CLI examples to avoid deprecated flags

### DIFF
--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -199,26 +199,23 @@ python zoom.py --frames 6 --mode gif --x-res 160 --y-res 160 \
 Resultado: `examples/cli-options/gif-frame-duration/slow.gif`
 
 ### `--save-frames` *(obsoleta)*
-Activa el modo histórico equivalente a `--mode frames`. No puede combinarse con `--mode`.
+Alias histórico de `--mode frames`. Se mantiene para compatibilidad pero emite una advertencia de deprecación. Usa el modo mo
+derno para evitar ruido en la salida:
 
-**Ejemplo**
 ```bash
-python zoom.py --frames 3 --save-frames \
-  --frame-dir examples/cli-options/save-frames/frames \
+python zoom.py --frames 3 --mode frames \
+  --frame-dir examples/cli-options/frame-dir/frames \
   --x-res 160 --y-res 160
 ```
-Resultado: secuencia en `examples/cli-options/save-frames/frames/` (se emite una advertencia de deprecación).
 
 ### `--save-mono` *(obsoleta)*
-Antiguo alias de `--mode mono`. Mantiene la salida en escala de grises.
+Alias histórico de `--mode mono`. Para producir secuencias en escala de grises sin advertencias, recurre al modo equivalente:
 
-**Ejemplo**
 ```bash
-python zoom.py --frames 3 --save-mono \
-  --frame-dir examples/cli-options/save-mono/mono \
+python zoom.py --frames 3 --mode mono \
+  --frame-dir examples/cli-options/mode/mono \
   --x-res 160 --y-res 160
 ```
-Resultado: secuencia monocromática en `examples/cli-options/save-mono/mono/` (con advertencia de deprecación).
 
 ### `--colormap`
 Selecciona el mapa de color de Matplotlib usado para colorear los valores suavizados.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -46,13 +46,13 @@ python zoom.py \
   --x-res 1440 \
   --y-res 1440 \
   --max-iterations 6000 \
-  --save-frames \
-  --frames-path deep_frames
+  --mode frames \
+  --frame-dir deep_frames
 ```
 
 - **Render time:** can take tens of minutes; recommend using a GPU.
 - **Result:** `movie.gif` plus `deep_frames/frameNNN.png` for manual selection.
-- **Tweak it:** point `--frames-path` to a fast SSD; if memory is tight, run in chunks (e.g. 300 frames at a time).
+- **Tweak it:** point `--frame-dir` to a fast SSD; if memory is tight, run in chunks (e.g. 300 frames at a time).
 
 ## 4. Static hero image
 

--- a/docs/output-modes.md
+++ b/docs/output-modes.md
@@ -4,7 +4,7 @@
 
 ## English summary
 
-The renderer currently follows a single hard-coded path: it collects every rendered frame in memory and always produces a `movie.gif` animation. Optional flags (`--save-frames`, `--save-mono`, `--frames-path`) sprinkle extra outputs on top of that workflow.
+The renderer currently follows a single hard-coded path: it collects every rendered frame in memory and always produces a `movie.gif` animation. Optional legacy flags (`--save-frames`, `--save-mono`, `--frames-path`) used to sprinkle extra outputs on top of that workflow, but they have been replaced by an explicit `--mode` selector and `--frame-dir`.
 
 The redesign proposes an explicit `--mode` flag that can be repeated to request artefacts such as `gif`, `image`, `frames`, and `mono`. This change would:
 
@@ -27,20 +27,20 @@ Under the proposal, legacy flags remain as aliases but emit deprecation notices.
 - El nombre del archivo (`movie.gif`) y la duración del cuadro están codificados; no existe un flag CLI para cambiarlos.
 
 ### 1.2 Guardado opcional de cuadros individuales
-- Los flags `--save-frames` y `--save-mono` activan la escritura en disco de los cuadros coloreados y/o monocromáticos.
-- Cuando alguno de estos flags está activo se crea (si es necesario) el directorio indicado por `--frames-path` (por defecto `./frames`).
+- Los modos `frames` y `mono` (`--mode frames`/`--mode mono`) —o sus alias históricos `--save-frames` y `--save-mono`— activan la escritura en disco de los cuadros coloreados y/o monocromáticos.
+- Cuando alguno de estos modos está activo se crea (si es necesario) el directorio indicado por `--frame-dir` (alias legacy: `--frames-path`, por defecto `./frames`).
 - Las imágenes coloreadas se guardan como `frame{NNN}.{format}`; el formato se controla con `--format` (valor por defecto `png`).
 - Las imágenes monocromáticas se guardan como `mono{NNN}.{format}` reutilizando el mismo formato indicado por `--format`.
 - Si `--show-edges` está activo, cada archivo `frame{NNN}` contiene la composición de la imagen RGB y la visualización de bordes concatenada.
 
 ### 1.3 Otros parámetros relevantes
-- `--save-frames` y `--save-mono` no afectan a la generación del GIF: este se produce siempre.
+- Los modos `frames` y `mono` (o sus alias) no afectan a la generación del GIF: este se produce siempre.
 - No hay forma de evitar la acumulación en memoria de todos los cuadros, ya que la lista `images` se necesita para guardar el GIF al final.
 - Tampoco existen rutas configurables para el GIF ni para un único fotograma final.
 
 ## 2. Limitaciones detectadas
 1. **Salida fija**: el flujo actual siempre produce `movie.gif`, incluso cuando el usuario solo desea un fotograma o una secuencia de archivos.
-2. **Flags superpuestos**: `--save-frames`, `--save-mono` y `--frames-path` representan modos de salida, pero se expresan como flags independientes que pueden entrar en combinaciones incoherentes.
+2. **Flags superpuestos**: `--mode frames`, `--mode mono` y la antigua `--frames-path` representan modos de salida, pero en su forma legacy se expresaban como flags independientes que podían generar combinaciones incoherentes.
 3. **Acumulación de memoria**: la necesidad de guardar todos los cuadros para crear el GIF puede ser un problema con secuencias largas.
 
 ## 3. Matriz de modos propuesta

--- a/scripts/generate_cli_examples.py
+++ b/scripts/generate_cli_examples.py
@@ -244,42 +244,6 @@ EXAMPLES: list[Example] = [
         clean=[EXAMPLES_ROOT / "gif-frame-duration"],
     ),
     Example(
-        name="save-frames",
-        args=[
-            "--frames",
-            "3",
-            "--save-frames",
-            "--frame-dir",
-            str(EXAMPLES_ROOT / "save-frames" / "frames"),
-            "--x-res",
-            "160",
-            "--y-res",
-            "160",
-        ],
-        expected=[
-            Expected(EXAMPLES_ROOT / "save-frames" / "frames", is_dir=True),
-        ],
-        clean=[EXAMPLES_ROOT / "save-frames"],
-    ),
-    Example(
-        name="save-mono",
-        args=[
-            "--frames",
-            "3",
-            "--save-mono",
-            "--frame-dir",
-            str(EXAMPLES_ROOT / "save-mono" / "mono"),
-            "--x-res",
-            "160",
-            "--y-res",
-            "160",
-        ],
-        expected=[
-            Expected(EXAMPLES_ROOT / "save-mono" / "mono", is_dir=True),
-        ],
-        clean=[EXAMPLES_ROOT / "save-mono"],
-    ),
-    Example(
         name="colormap",
         args=[*BASE_ARGS, "--colormap", "inferno", "--output", str(EXAMPLES_ROOT / "colormap" / "inferno.png")],
         expected=[Expected(EXAMPLES_ROOT / "colormap" / "inferno.png")],


### PR DESCRIPTION
## Summary
- switch the deep dive playbook recipe to the modern `--mode frames` / `--frame-dir` flags
- rewrite the legacy sections in the CLI reference to point to the new mode-based commands
- drop the deprecated `save-frames` and `save-mono` entries from the CLI example generator and refresh the output-modes overview

## Testing
- python scripts/generate_cli_examples.py

------
https://chatgpt.com/codex/tasks/task_e_68d589e77768832fbc7f3f6a21d25110